### PR TITLE
add changelog audit workflow

### DIFF
--- a/.github/workflows/changelog-audit.yml
+++ b/.github/workflows/changelog-audit.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - name: 'testoing'
         run: |
+          echo "testing the changelog audit action"
           echo ${{ inputs.event_path }}
 #      - uses: actions/checkout@v4
 #        with:

--- a/.github/workflows/changelog-audit.yml
+++ b/.github/workflows/changelog-audit.yml
@@ -1,0 +1,35 @@
+on:
+  # When a reusable workflow is triggered by a caller workflow,
+  # the github context is always associated with the caller workflow.
+  workflow_call:
+    inputs:
+      event_path:
+        required: false
+        type: string
+        default: ${{ github.event_path }}
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: 'sourcegraph/devx-service'
+          token: ${{ secrets.DEVX_TOKEN }}
+
+      - uses: actions/setup-go@v4
+        with: { go-version: '1.22' }
+
+      - run: |
+          # Get the latest release tag name from devx-service
+          tagName=$(gh release -R sourcegraph/devx-service list --exclude-drafts --exclude-pre-releases -L 1 --json tagName -q '.[] | .tagName')
+          # Download the changelog asset from the release
+          gh release -R sourcegraph/devx-service download ${tagName} --pattern changelog
+
+          chmod +x ./changelog
+
+          ./changelog audit
+        env:
+          GITHUB_EVENT_PATH: ${{ inputs.event_path }}
+          GH_TOKEN: ${{ secrets.DEVX_TOKEN }}
+          GITHUB_LOGIN: "sourcegraph-bot-devx"

--- a/.github/workflows/changelog-audit.yml
+++ b/.github/workflows/changelog-audit.yml
@@ -7,6 +7,13 @@ on:
         required: true
         type: string
 
+    secrets:
+      github_devx_token:
+        required: true
+        description: |
+          This is the token used to checkout the `devx-service` repo and post comments
+          to the pull request in which the audit command is being run against.
+
 jobs:
   audit:
     runs-on: ubuntu-latest
@@ -14,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: 'sourcegraph/devx-service'
-          token: ${{ secrets.DEVX_TOKEN }}
+          token: ${{ secrets.github_devx_token }}
 
       - uses: actions/setup-go@v4
         with: { go-version: '1.22' }

--- a/.github/workflows/changelog-audit.yml
+++ b/.github/workflows/changelog-audit.yml
@@ -11,29 +11,24 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - name: 'testoing'
-        run: |
-          echo "testing the changelog audit action"
-          echo ${{ inputs.github_event_path }}
-          cat ${{ inputs.github_event_path }}
-#      - uses: actions/checkout@v4
-#        with:
-#          repository: 'sourcegraph/devx-service'
-#          token: ${{ secrets.DEVX_TOKEN }}
-#
-#      - uses: actions/setup-go@v4
-#        with: { go-version: '1.22' }
-#
-#      - run: |
-#          # Get the latest release tag name from devx-service
-#          tagName=$(gh release -R sourcegraph/devx-service list --exclude-drafts --exclude-pre-releases -L 1 --json tagName -q '.[] | .tagName')
-#          # Download the changelog asset from the release
-#          gh release -R sourcegraph/devx-service download ${tagName} --pattern changelog
-#
-#          chmod +x ./changelog
-#
-#          ./changelog audit
-#        env:
-#          GITHUB_EVENT_PATH: ${{ inputs.event_path }}
-#          GH_TOKEN: ${{ secrets.DEVX_TOKEN }}
-#          GITHUB_LOGIN: "sourcegraph-bot-devx"
+      - uses: actions/checkout@v4
+        with:
+          repository: 'sourcegraph/devx-service'
+          token: ${{ secrets.DEVX_TOKEN }}
+
+      - uses: actions/setup-go@v4
+        with: { go-version: '1.22' }
+
+      - run: |
+          # Get the latest release tag name from devx-service
+          tagName=$(gh release -R sourcegraph/devx-service list --exclude-drafts --exclude-pre-releases -L 1 --json tagName -q '.[] | .tagName')
+          # Download the changelog asset from the release
+          gh release -R sourcegraph/devx-service download ${tagName} --pattern changelog
+
+          chmod +x ./changelog
+
+          ./changelog audit
+        env:
+          GITHUB_EVENT_PATH: ${{ inputs.github_event_path }}
+          GH_TOKEN: ${{ secrets.DEVX_TOKEN }}
+          GITHUB_LOGIN: "sourcegraph-bot-devx"

--- a/.github/workflows/changelog-audit.yml
+++ b/.github/workflows/changelog-audit.yml
@@ -8,7 +8,7 @@ on:
         type: string
 
     secrets:
-      github_devx_token:
+      GITHUB_DEVX_TOKEN:
         required: true
         description: |
           This is the token used to checkout the `devx-service` repo and post comments
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: 'sourcegraph/devx-service'
-          token: ${{ secrets.github_devx_token }}
+          token: ${{ secrets.GITHUB_DEVX_TOKEN }}
 
       - uses: actions/setup-go@v4
         with: { go-version: '1.22' }
@@ -37,5 +37,5 @@ jobs:
           ./changelog audit
         env:
           GITHUB_EVENT_PATH: ${{ inputs.github_event_path }}
-          GH_TOKEN: ${{ secrets.DEVX_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_DEVX_TOKEN }}
           GITHUB_LOGIN: "sourcegraph-bot-devx"

--- a/.github/workflows/changelog-audit.yml
+++ b/.github/workflows/changelog-audit.yml
@@ -12,24 +12,27 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: 'sourcegraph/devx-service'
-          token: ${{ secrets.DEVX_TOKEN }}
-
-      - uses: actions/setup-go@v4
-        with: { go-version: '1.22' }
-
-      - run: |
-          # Get the latest release tag name from devx-service
-          tagName=$(gh release -R sourcegraph/devx-service list --exclude-drafts --exclude-pre-releases -L 1 --json tagName -q '.[] | .tagName')
-          # Download the changelog asset from the release
-          gh release -R sourcegraph/devx-service download ${tagName} --pattern changelog
-
-          chmod +x ./changelog
-
-          ./changelog audit
-        env:
-          GITHUB_EVENT_PATH: ${{ inputs.event_path }}
-          GH_TOKEN: ${{ secrets.DEVX_TOKEN }}
-          GITHUB_LOGIN: "sourcegraph-bot-devx"
+      - name: 'testoing'
+        run: |
+          echo ${{ inputs.event_path }}
+#      - uses: actions/checkout@v4
+#        with:
+#          repository: 'sourcegraph/devx-service'
+#          token: ${{ secrets.DEVX_TOKEN }}
+#
+#      - uses: actions/setup-go@v4
+#        with: { go-version: '1.22' }
+#
+#      - run: |
+#          # Get the latest release tag name from devx-service
+#          tagName=$(gh release -R sourcegraph/devx-service list --exclude-drafts --exclude-pre-releases -L 1 --json tagName -q '.[] | .tagName')
+#          # Download the changelog asset from the release
+#          gh release -R sourcegraph/devx-service download ${tagName} --pattern changelog
+#
+#          chmod +x ./changelog
+#
+#          ./changelog audit
+#        env:
+#          GITHUB_EVENT_PATH: ${{ inputs.event_path }}
+#          GH_TOKEN: ${{ secrets.DEVX_TOKEN }}
+#          GITHUB_LOGIN: "sourcegraph-bot-devx"

--- a/.github/workflows/changelog-audit.yml
+++ b/.github/workflows/changelog-audit.yml
@@ -3,7 +3,7 @@ on:
   # the github context is always associated with the caller workflow.
   workflow_call:
     inputs:
-      event_path:
+      github_event_path:
         required: false
         type: string
         default: ${{ github.event_path }}
@@ -15,7 +15,8 @@ jobs:
       - name: 'testoing'
         run: |
           echo "testing the changelog audit action"
-          echo ${{ inputs.event_path }}
+          echo ${{ inputs.github_event_path }}
+          cat ${{ inputs.github_event_path }}
 #      - uses: actions/checkout@v4
 #        with:
 #          repository: 'sourcegraph/devx-service'

--- a/.github/workflows/changelog-audit.yml
+++ b/.github/workflows/changelog-audit.yml
@@ -4,9 +4,8 @@ on:
   workflow_call:
     inputs:
       github_event_path:
-        required: false
+        required: true
         type: string
-        default: ${{ github.event_path }}
 
 jobs:
   audit:


### PR DESCRIPTION
This introduces the `changelog audit` workflow to the list of reusable workflows at Sourcegraph.